### PR TITLE
Add `FEET_PER_MILE` macro and use it throughout

### DIFF
--- a/common.h
+++ b/common.h
@@ -20,6 +20,7 @@
 #define	METERS_PER_MILE 1609.344
 #define	METERS_PER_FOOT 0.3048
 #define	KM_PER_MILE	1.609344
+#define	FEET_PER_MILE	5280.0
 #define FOUR_THIRDS	1.3333333333333
 
 #define MAX(x,y)((x)>(y)?(x):(y))

--- a/main.cc
+++ b/main.cc
@@ -454,7 +454,7 @@ double ElevationAngle(struct site source, struct site destination)
 	a = GetElevation(destination) + destination.alt + earthradius;
 	b = GetElevation(source) + source.alt + earthradius;
 
-	dx = 5280.0 * Distance(source, destination);
+	dx = FEET_PER_MILE * Distance(source, destination);
 
 	/* Apply the Law of Cosines */
 
@@ -591,7 +591,7 @@ double ElevationAngle2(struct site source, struct site destination, double er)
 
 	ReadPath(source, destination);
 
-	distance = 5280.0 * Distance(source, destination);
+	distance = FEET_PER_MILE * Distance(source, destination);
 	source_alt = er + source.alt + GetElevation(source);
 	destination_alt = er + destination.alt + GetElevation(destination);
 	source_alt2 = source_alt * source_alt;
@@ -611,7 +611,7 @@ double ElevationAngle2(struct site source, struct site destination, double er)
 	   obstruction along the path between source and destination. */
 
 	for (x = 2, block = 0; x < path.length && block == 0; x++) {
-		distance = 5280.0 * path.distance[x];
+		distance = FEET_PER_MILE * path.distance[x];
 
 		test_alt =
 		    earthradius + (path.elevation[x] ==
@@ -729,7 +729,7 @@ void ObstructionAnalysis(struct site xmtr, struct site rcvr, double f,
 	h_r_fpt6 = h_r;
 	h_r_orig = h_r;
 	h_t = GetElevation(xmtr) + xmtr.alt + earthradius;
-	d_tx = 5280.0 * Distance(rcvr, xmtr);
+	d_tx = FEET_PER_MILE * Distance(rcvr, xmtr);
 	cos_tx_angle =
 	    ((h_r * h_r) + (d_tx * d_tx) - (h_t * h_t)) / (2.0 * h_r * d_tx);
 	cos_tx_angle_f1 = cos_tx_angle;
@@ -770,7 +770,7 @@ void ObstructionAnalysis(struct site xmtr, struct site rcvr, double f,
 		site_x.alt = 0.0;
 
 		h_x = GetElevation(site_x) + earthradius + clutter;
-		d_x = 5280.0 * Distance(rcvr, site_x);
+		d_x = FEET_PER_MILE * Distance(rcvr, site_x);
 
 		/* Deal with the LOS path first. */
 
@@ -789,14 +789,14 @@ void ObstructionAnalysis(struct site xmtr, struct site rcvr, double f,
 					fprintf(outfile,
 						"   %8.4f N,%9.4f W, %5.2f kilometers, %6.2f meters AMSL\n",
 						site_x.lat, site_x.lon,
-						KM_PER_MILE * (d_x / 5280.0),
+						KM_PER_MILE * (d_x / FEET_PER_MILE),
 						METERS_PER_FOOT * (h_x -
 								   earthradius));
 				else
 					fprintf(outfile,
 						"   %8.4f N,%9.4f W, %5.2f miles, %6.2f feet AMSL\n",
 						site_x.lat, site_x.lon,
-						d_x / 5280.0,
+						d_x / FEET_PER_MILE,
 						h_x - earthradius);
 			}
 
@@ -805,14 +805,14 @@ void ObstructionAnalysis(struct site xmtr, struct site rcvr, double f,
 					fprintf(outfile,
 						"   %8.4f S,%9.4f W, %5.2f kilometers, %6.2f meters AMSL\n",
 						-site_x.lat, site_x.lon,
-						KM_PER_MILE * (d_x / 5280.0),
+						KM_PER_MILE * (d_x / FEET_PER_MILE),
 						METERS_PER_FOOT * (h_x -
 								   earthradius));
 				else
 					fprintf(outfile,
 						"   %8.4f S,%9.4f W, %5.2f miles, %6.2f feet AMSL\n",
 						-site_x.lat, site_x.lon,
-						d_x / 5280.0,
+						d_x / FEET_PER_MILE,
 						h_x - earthradius);
 			}
 		}

--- a/models/los.cc
+++ b/models/los.cc
@@ -251,7 +251,7 @@ void PlotLOSPath(struct site source, struct site destination, char mask_value,
 		if ((GetMask(path.lat[y], path.lon[y]) & mask_value) == 0
 			&& can_process(path.lat[y], path.lon[y])) {
 
-			distance = 5280.0 * path.distance[y];
+			distance = FEET_PER_MILE * path.distance[y];
 			tx_alt = earthradius + source.alt + path.elevation[0];
 			rx_alt =
 			    earthradius + destination.alt + path.elevation[y];
@@ -265,7 +265,7 @@ void PlotLOSPath(struct site source, struct site destination, char mask_value,
 
 			for (x = y, block = 0; x >= 0 && block == 0; x--) {
 				distance =
-				    5280.0 * (path.distance[y] -
+				    FEET_PER_MILE * (path.distance[y] -
 					      path.distance[x]);
 				test_alt =
 				    earthradius + (path.elevation[x] ==
@@ -352,7 +352,7 @@ void PlotPropPath(struct site source, struct site destination,
 			char fd_buffer[64];
 			int buffer_offset = 0;
 
-			distance = 5280.0 * path.distance[y];
+			distance = FEET_PER_MILE * path.distance[y];
 			xmtr_alt =
 			    four_thirds_earth + source.alt + path.elevation[0];
 			dest_alt =
@@ -381,7 +381,7 @@ void PlotPropPath(struct site source, struct site destination,
 
 				for (x = 2, block = 0; (x < y && block == 0);
 				     x++) {
-					distance = 5280.0 * path.distance[x];
+					distance = FEET_PER_MILE * path.distance[x];
 
 					test_alt =
 					    four_thirds_earth +
@@ -892,7 +892,7 @@ void PlotPath(struct site source, struct site destination, char mask_value)
 		   tested and found to be free of obstructions. */
 
 		if ((GetMask(path.lat[y], path.lon[y]) & mask_value) == 0) {
-			distance = 5280.0 * path.distance[y];
+			distance = FEET_PER_MILE * path.distance[y];
 			tx_alt = earthradius + source.alt + path.elevation[0];
 			rx_alt =
 			    earthradius + destination.alt + path.elevation[y];
@@ -906,7 +906,7 @@ void PlotPath(struct site source, struct site destination, char mask_value)
 
 			for (x = y, block = 0; x >= 0 && block == 0; x--) {
 				distance =
-				    5280.0 * (path.distance[y] -
+				    FEET_PER_MILE * (path.distance[y] -
 					      path.distance[x]);
 				test_alt =
 				    earthradius + (path.elevation[x] ==

--- a/outputs.cc
+++ b/outputs.cc
@@ -1335,7 +1335,7 @@ void PathReport(struct site source, struct site destination, char *name,
 		azimuth = rint(Azimuth(source, destination));
 
 		for (y = 2; y < (path.length - 1); y++) {	/* path.length-1 avoids LR error */
-			distance = 5280.0 * path.distance[y];
+			distance = FEET_PER_MILE * path.distance[y];
 
 			source_alt = four_thirds_earth + source.alt + path.elevation[0];
 			dest_alt = four_thirds_earth + destination.alt +
@@ -1357,7 +1357,7 @@ void PathReport(struct site source, struct site destination, char *name,
 
 				for (x = 2, block = 0; x < y && block == 0; x++) {
 					distance =
-					    5280.0 * (path.distance[y] -
+					    FEET_PER_MILE * (path.distance[y] -
 						      path.distance[x]);
 					test_alt =
 					    four_thirds_earth +
@@ -1769,7 +1769,7 @@ void SeriesData(struct site source, struct site destination, char *name,
 
 	if (fresnel_plot) {
 		lambda = 9.8425e8 / (LR.frq_mhz * 1e6);
-		d = 5280.0 * path.distance[path.length - 1];
+		d = FEET_PER_MILE * path.distance[path.length - 1];
 	}
 
 	if (normalised) {
@@ -1812,7 +1812,7 @@ void SeriesData(struct site source, struct site destination, char *name,
 			terrain += destination.alt;	/* RX antenna spike */
 
 		a = terrain + earthradius;
-		cangle = 5280.0 * Distance(destination, remote) / earthradius;
+		cangle = FEET_PER_MILE * Distance(destination, remote) / earthradius;
 		c = b * sin(refangle * DEG2RAD + HALFPI) / sin(HALFPI -
 							       refangle *
 							       DEG2RAD -
@@ -1830,7 +1830,7 @@ void SeriesData(struct site source, struct site destination, char *name,
 
 		if ((LR.frq_mhz >= 20.0) && (LR.frq_mhz <= 100000.0)
 		    && fresnel_plot) {
-			d1 = 5280.0 * path.distance[x];
+			d1 = FEET_PER_MILE * path.distance[x];
 			f_zone = -1.0 * sqrt(lambda * d1 * (d - d1) / d);
 			fpt6_zone = f_zone * fzone_clearance;
 		}


### PR DESCRIPTION
The macro replaces uses of the float value 5280.0 (being the
number of feet in a mile).

This improves readability, particularly for readers from metric
backgrounds.